### PR TITLE
pc - add more stories to navbar

### DIFF
--- a/frontend/src/stories/components/Nav/AppNavbar.stories.js
+++ b/frontend/src/stories/components/Nav/AppNavbar.stories.js
@@ -2,6 +2,8 @@
 import React from 'react';
 
 import AppNavbar from "main/components/Nav/AppNavbar";
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { systemInfoFixtures } from 'fixtures/systemInfoFixtures';
 
 export default {
     title: 'components/Nav/AppNavbar',
@@ -15,27 +17,62 @@ const Template = (args) => {
     )
 };
 
-export const noRole = Template.bind({});
+export const basic_notLoggedIn = Template.bind({});
 
-export const admin = Template.bind({});
-admin.args = {
-    role: "admin"
+
+export const basic_loggedInAdminUser = Template.bind({});
+basic_loggedInAdminUser.args = {
+    currentUser: currentUserFixtures.adminUser
 };
 
-export const localhost3000 = Template.bind({});
-localhost3000.args = {
+export const basic_loggedInRegularUser = Template.bind({});
+basic_loggedInRegularUser.args = {
+    currentUser: currentUserFixtures.userOnly
+};
+
+export const extraLinks_neitherH2NorSwagger = Template.bind({});
+extraLinks_neitherH2NorSwagger.args = {
+    currentUser: currentUserFixtures.userOnly,
+    systemInfo: systemInfoFixtures.showingNeither
+};
+
+export const extraLinks_H2Only = Template.bind({});
+extraLinks_H2Only.args = {
+    currentUser: currentUserFixtures.userOnly,
+    systemInfo: {
+        "springH2ConsoleEnabled": true,
+        "showSwaggerUILink": false,
+    }
+};
+
+export const extraLinks_SwaggerOnly = Template.bind({});
+extraLinks_SwaggerOnly.args = {
+    currentUser: currentUserFixtures.userOnly,
+    systemInfo: {
+        "springH2ConsoleEnabled": false,
+        "showSwaggerUILink": true,
+    }
+};
+
+export const extraLinks_bothH2AndSwagger = Template.bind({});
+extraLinks_bothH2AndSwagger.args = {
+    currentUser: currentUserFixtures.userOnly,
+    systemInfo: systemInfoFixtures.showingBoth
+};
+
+
+export const localhost_3000 = Template.bind({});
+localhost_3000.args = {
     currentUrl: "http://localhost:3000"
 };
 
-export const localhostNumeric3000 = Template.bind({});
-localhostNumeric3000.args = {
+export const localhost_127_0_0_1__3000 = Template.bind({});
+localhost_127_0_0_1__3000.args = {
     currentUrl: "http://127.0.0.1:3000"
 };
 
-export const localhost8080 = Template.bind({});
-localhost8080.args = {
+export const localhost_8080 = Template.bind({});
+localhost_8080.args = {
     currentUrl: "http://localhost:8080"
 };
-
-
 


### PR DESCRIPTION
In this PR, we add a few additional stories to the storybook for the navbar.

The additional stories show the navbar under various conditions that we were not showing before:
* Logged in as an admin
* Logged in as a regular user
* When the H2 and Swagger links are present or absent in all possible combinations

The purpose is to allow us to visualize changes to the navbar in later stories more easily.

# Screenshots

## Before

There were a limited number of stories. 

<img width="246" alt="image" src="https://user-images.githubusercontent.com/1119017/170847443-f86f838c-4afa-4a8f-9535-9577dacb5e23.png">

The `Admin` and `No Role` stories actually did not work; they were left over from an entirely different way of handing authentication.  For example, here's what the `Admin` story looked like: note it doesn't even show as logged in:

<img width="1345" alt="image" src="https://user-images.githubusercontent.com/1119017/170847490-b01e42a3-e50e-4b3b-96e6-876fa127a3bb.png">


## After

There are far more stories:

<img width="248" alt="image" src="https://user-images.githubusercontent.com/1119017/170847525-7bde256c-0de4-4cee-a2f9-85712a7379cb.png">


And the stories actually do what they say they should do.  For example, here's the [`Basic Logged in  Admin User`](https://ucsb-cs156-s22.github.io/s22-6pm-courses-docs-qa/storybook-qa/pc-nav-bar-storybook-improvements/?path=/story/components-nav-appnavbar--basic-logged-in-admin-user) story: 

<img width="1354" alt="image" src="https://user-images.githubusercontent.com/1119017/170847536-8ba099c8-338e-4129-809c-95c5a3b0c7da.png">

And the [`Basic Logged in Regular User`](https://ucsb-cs156-s22.github.io/s22-6pm-courses-docs-qa/storybook-qa/pc-nav-bar-storybook-improvements/?path=/story/components-nav-appnavbar--basic-logged-in-regular-user) story

<img width="1348" alt="image" src="https://user-images.githubusercontent.com/1119017/170847559-5e18e94d-1d34-48c4-ad29-0ab263746a81.png">

There are several others; to try them all, visit: 

* <https://ucsb-cs156-s22.github.io/s22-6pm-courses-docs-qa/storybook-qa/pc-nav-bar-storybook-improvements/> and navigate to `components / Nav / AppNavbar `

# Testing Plan:

Look at the QA Storybook, and look at each story under NavBar.   Examine it to see if the NavBar looks as it should.


