### PR TITLE
s22-6pm-1 Kevin - Add API endpoint for getting course information with detailed section info in a useable form.

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.courses.controllers;
 
+import java.util.List;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
 
 @RestController
 @RequestMapping("/api/public")
@@ -37,5 +40,13 @@ public class UCSBCurriculumController {
         String body = ucsbCurriculumService.getJSON(dept, qtr, level);
         
         return ResponseEntity.ok().body(body);
+    } 
+    @GetMapping(value = "/sectionsearch", produces = "application/json")
+    public List<ConvertedSection> sectionsearch(@RequestParam String qtr, @RequestParam String dept,
+            @RequestParam String level) throws JsonProcessingException {
+
+        List<ConvertedSection> sections = ucsbCurriculumService.getConvertedSections(dept, qtr, level);
+        
+        return sections;
     }      
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
@@ -3,6 +3,9 @@ package edu.ucsb.cs156.courses.controllers;
 import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.CoursePage;
+import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
 
 import org.junit.jupiter.api.Test;
 
@@ -23,6 +26,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.ArrayList;
 
 @WebMvcTest(value = UCSBCurriculumController.class)
 @Import(SecurityConfig.class)
@@ -47,6 +53,25 @@ public class UCSBCurriculumControllerTests {
         String url = String.format(urlTemplate, "20204", "CMPSC", "L");
         when(ucsbCurriculumService.getJSON(any(String.class), any(String.class), any(String.class)))
                 .thenReturn(expectedResult);
+
+        MvcResult response = mockMvc.perform(get(url).contentType("application/json")).andExpect(status().isOk())
+                .andReturn();
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(expectedResult, responseString);
+    }
+
+    @Test
+    public void test_sectionsearch() throws Exception {
+        
+        CoursePage cp = CoursePage.fromJSON(CoursePageFixtures.COURSE_PAGE_JSON_MATH3B);
+        List<ConvertedSection> convertedSections = cp.convertedSections();
+        ObjectMapper objectMapper = new ObjectMapper();
+        String expectedResult = objectMapper.writeValueAsString(convertedSections);
+        String urlTemplate = "/api/public/sectionsearch?qtr=%s&dept=%s&level=%s";
+        String url = String.format(urlTemplate, "20204", "CMPSC", "L");
+        when(ucsbCurriculumService.getConvertedSections(any(String.class), any(String.class), any(String.class)))
+                .thenReturn(convertedSections);
 
         MvcResult response = mockMvc.perform(get(url).contentType("application/json")).andExpect(status().isOk())
                 .andReturn();


### PR DESCRIPTION
In this PR, we added an API endpoint to the backend which retrieves all sections and their relevant information given a department, level, and quarter. Closes #4.

<img width="1416" alt="image" src="https://user-images.githubusercontent.com/67876254/171067211-6857e7a3-0f75-4685-be65-6e0f754e0431.png">
<img width="1416" alt="image" src="https://user-images.githubusercontent.com/67876254/171067226-61f6a6b4-2539-4547-a312-d57710761dae.png">
