### PR TITLE
s22-6pm-2 Mikey Added Placeholder page and dynamic routing for personal schedules.

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -37,7 +37,7 @@ function App() {
             <>
               <Route exact path="/personalschedules/list" element={<PersonalSchedulesIndexPage />} />
               <Route exact path="/personalschedules/create" element={<PersonalSchedulesCreatePage />} />
-              <Route path="/personalschedules/:scheduleID" element={<PersonalScheduleInfoPage />} />
+              <Route exact path="/personalschedules/:scheduleID" element={<PersonalScheduleInfoPage />} />
             </>
           )
         }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import "bootstrap/dist/css/bootstrap.css";
 
 import PersonalSchedulesIndexPage from "main/pages/PersonalSchedules/PersonalSchedulesIndexPage";
 import PersonalSchedulesCreatePage from "main/pages/PersonalSchedules/PersonalSchedulesCreatePage";
+import PersonalScheduleInfoPage from "main/pages/PersonalSchedules/PersonalScheduleInfoPage";
 
 
 function App() {
@@ -36,6 +37,7 @@ function App() {
             <>
               <Route exact path="/personalschedules/list" element={<PersonalSchedulesIndexPage />} />
               <Route exact path="/personalschedules/create" element={<PersonalSchedulesCreatePage />} />
+              <Route path="/personalschedules/:scheduleID" element={<PersonalScheduleInfoPage />} />
             </>
           )
         }

--- a/frontend/src/main/components/PersonalSchedules/PersonalSchedulesTable.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalSchedulesTable.js
@@ -7,6 +7,7 @@ import { hasRole } from "main/utils/currentUser";
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 
 export default function PersonalSchedulesTable({ personalSchedules, currentUser }) {
+
     const navigate = useNavigate();
 
     const editCallback = (cell) => {
@@ -40,7 +41,10 @@ export default function PersonalSchedulesTable({ personalSchedules, currentUser 
         },
         {
             Header: 'Quarter',
-            accessor: (row, _rowIndex) => yyyyqToQyy(row.quarter),
+            accessor: (row, _rowIndex) => {
+                if(row?.quarter){return yyyyqToQyy(row.quarter)}
+                return "";
+            },
             id: 'quarter',
         },
     ];

--- a/frontend/src/main/pages/PersonalSchedules/PersonalScheduleInfoPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalScheduleInfoPage.js
@@ -22,7 +22,7 @@ export default function PersonalScheduleInfoPage() {
         <BasicLayout>
             <div className="pt-2">
                 <h1>PersonalScheduleInfo</h1>
-                <PersonalSchedulesTable personalSchedules={personalSchedule ? [personalSchedule] : []} currentUser={currentUser} />
+                {(personalSchedule != []) && <PersonalSchedulesTable personalSchedules={[personalSchedule]} currentUser={currentUser} />}
             </div>
         </BasicLayout>
     )

--- a/frontend/src/main/pages/PersonalSchedules/PersonalScheduleInfoPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalScheduleInfoPage.js
@@ -12,17 +12,19 @@ export default function PersonalScheduleInfoPage() {
     
     const { data: personalSchedule, error: _error, status: _status } =
         useBackend(
-            // Stryker disable next-line all : don't test internal caching of React Query
+            // Stryker disable all : don't make sense to mutation test here
             ["/api/personalschedules", `${scheduleID}` ],
             { method: "GET", url: `/api/personalschedules?id=${scheduleID}` },
             []
+            // Stryker enable all
         );
 
     return (
         <BasicLayout>
             <div className="pt-2">
                 <h1>PersonalScheduleInfo</h1>
-                {(personalSchedule !== []) && <PersonalSchedulesTable personalSchedules={[personalSchedule]} currentUser={currentUser} />}
+                { // Stryker disable next-line all: we only want to check against empty array
+                (personalSchedule !== []) && <PersonalSchedulesTable personalSchedules={[personalSchedule]} currentUser={currentUser} />}
             </div>
         </BasicLayout>
     )

--- a/frontend/src/main/pages/PersonalSchedules/PersonalScheduleInfoPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalScheduleInfoPage.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend';
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import PersonalSchedulesTable from 'main/components/PersonalSchedules/PersonalSchedulesTable';
+import { useCurrentUser } from 'main/utils/currentUser'
+import { useParams } from 'react-router-dom'
+
+export default function PersonalScheduleInfoPage() {
+    const {scheduleID} = useParams();
+    const currentUser = useCurrentUser();
+    
+    const { data: personalSchedule, error: _error, status: _status } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            ["/api/personalschedules", `${scheduleID}` ],
+            { method: "GET", url: `/api/personalschedules?id=${scheduleID}` },
+            []
+        );
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>PersonalScheduleInfo</h1>
+                <PersonalSchedulesTable personalSchedules={personalSchedule ? [personalSchedule] : []} currentUser={currentUser} />
+            </div>
+        </BasicLayout>
+    )
+}

--- a/frontend/src/main/pages/PersonalSchedules/PersonalScheduleInfoPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalScheduleInfoPage.js
@@ -22,7 +22,7 @@ export default function PersonalScheduleInfoPage() {
         <BasicLayout>
             <div className="pt-2">
                 <h1>PersonalScheduleInfo</h1>
-                {(personalSchedule != []) && <PersonalSchedulesTable personalSchedules={[personalSchedule]} currentUser={currentUser} />}
+                {(personalSchedule !== []) && <PersonalSchedulesTable personalSchedules={[personalSchedule]} currentUser={currentUser} />}
             </div>
         </BasicLayout>
     )

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -26,7 +26,6 @@ import { toast } from "react-toastify";
 // );
 
 export function useBackend(queryKey, axiosParameters, initialData) {
-
     return useQuery(queryKey, async () => {
         try {
             const response = await axios(axiosParameters);

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalScheduleInfoPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalScheduleInfoPage.test.js
@@ -1,9 +1,8 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import mockConsole from "jest-mock-console";
 
 import PersonalScheduleInfoPage from "main/pages/PersonalSchedules/PersonalScheduleInfoPage";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalScheduleInfoPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalScheduleInfoPage.test.js
@@ -8,7 +8,7 @@ import mockConsole from "jest-mock-console";
 import PersonalScheduleInfoPage from "main/pages/PersonalSchedules/PersonalScheduleInfoPage";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
-import { personalScheduleFixtures } from "fixtures/personalScheduleFixtures";
+import { personalSchedulesFixtures } from "fixtures/personalSchedulesFixtures";
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
@@ -21,6 +21,7 @@ jest.mock('react-toastify', () => {
 });
 
 describe("PersonalScheduleInfoPage tests", () => {
+
 
     const axiosMock = new AxiosMockAdapter(axios);
 
@@ -40,10 +41,13 @@ describe("PersonalScheduleInfoPage tests", () => {
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
     
-    test("renders without crashing for regular user", () => {
+    test("renders without crashing for regular user", async() => {
+
+        console.log(personalSchedulesFixtures.onePersonalSchedule);
+        
         setupUserOnly();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/personalschedules/1").reply(200, personalScheduleFixtures.onePersonalSchedules);
+        axiosMock.onGet("/api/personalschedules/1").reply(200, personalSchedulesFixtures.onePersonalSchedule);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -52,6 +56,12 @@ describe("PersonalScheduleInfoPage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
+        
+        await waitFor(() => {
+            expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+        });
+        expect(await screen.findByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(1);
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("TestName");
 
 
     });
@@ -59,7 +69,7 @@ describe("PersonalScheduleInfoPage tests", () => {
     test("renders without crashing for admin user", () => {
         setupAdminUser();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/personalschedules/1").reply(200, null);
+        axiosMock.onGet("/api/personalschedules/1").reply(200, personalSchedulesFixtures.onePersonalSchedule);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -78,7 +88,7 @@ describe("PersonalScheduleInfoPage tests", () => {
 
         setupUserOnly();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/personalschedules/5").reply(404, personalScheduleFixtures.onePersonalSchedules);
+        axiosMock.onGet("/api/personalschedules/5").reply(404);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -98,7 +108,7 @@ describe("PersonalScheduleInfoPage tests", () => {
 
         setupAdminUser();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/personalschedules/5").reply(404, personalScheduleFixtures.onePersonalSchedules);
+        axiosMock.onGet("/api/personalschedules/5").reply(404);
 
         render(
             <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalScheduleInfoPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalScheduleInfoPage.test.js
@@ -30,6 +30,14 @@ jest.mock('react-router-dom', () => {
     };
 });
 
+beforeEach(() => {
+    jest.spyOn(console, 'error')
+    console.error.mockImplementation(() => null);
+  });
+
+afterEach(() => {
+    console.error.mockRestore()
+})
 describe("PersonalScheduleInfoPage tests", () => {
 
 
@@ -98,9 +106,6 @@ describe("PersonalScheduleInfoPage tests", () => {
     });
 
     test("returns 404 when regular user tries to get info page of invalid id", () => {
-        jest.spyOn(console, 'error')
-        console.error.mockImplementation(() => null);
-
         setupUserOnly();
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/personalschedules?id=5").reply(404);
@@ -113,14 +118,9 @@ describe("PersonalScheduleInfoPage tests", () => {
             </QueryClientProvider>
         );
 
-        console.error.mockRestore()
-
     });
 
     test("returns 404 when admin tries to get info page of invalid id", () => {
-        jest.spyOn(console, 'error')
-        console.error.mockImplementation(() => null);
-
         setupAdminUser();
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/personalschedules?id=5").reply(404);
@@ -132,8 +132,5 @@ describe("PersonalScheduleInfoPage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
-
-        console.error.mockRestore()
-
     });
 });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalScheduleInfoPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalScheduleInfoPage.test.js
@@ -20,6 +20,17 @@ jest.mock('react-toastify', () => {
     };
 });
 
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom'); // use actual for all non-hook parts
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            scheduleID: 1
+        })
+    };
+});
+
 describe("PersonalScheduleInfoPage tests", () => {
 
 
@@ -42,12 +53,10 @@ describe("PersonalScheduleInfoPage tests", () => {
     };
     
     test("renders without crashing for regular user", async() => {
-
-        console.log(personalSchedulesFixtures.onePersonalSchedule);
         
         setupUserOnly();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/personalschedules/1").reply(200, personalSchedulesFixtures.onePersonalSchedule);
+        axiosMock.onGet("/api/personalschedules?id=1").reply(200, personalSchedulesFixtures.onePersonalSchedule);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -58,18 +67,18 @@ describe("PersonalScheduleInfoPage tests", () => {
         );
         
         await waitFor(() => {
-            expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+            expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(3);
         });
-        expect(await screen.findByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(1);
-        expect(screen.getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("TestName");
-
-
+        
+        expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(1);
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("TestName");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-description`)).toHaveTextContent("TestDescription");
     });
 
-    test("renders without crashing for admin user", () => {
+    test("renders without crashing for admin user", async() => {
         setupAdminUser();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/personalschedules/1").reply(200, personalSchedulesFixtures.onePersonalSchedule);
+        axiosMock.onGet("/api/personalschedules?id=1").reply(200, personalSchedulesFixtures.onePersonalSchedule);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -79,6 +88,13 @@ describe("PersonalScheduleInfoPage tests", () => {
             </QueryClientProvider>
         );
 
+        await waitFor(() => {
+            expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(3);
+        });
+        
+        expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(1);
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("TestName");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-description`)).toHaveTextContent("TestDescription");
 
     });
 
@@ -88,7 +104,7 @@ describe("PersonalScheduleInfoPage tests", () => {
 
         setupUserOnly();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/personalschedules/5").reply(404);
+        axiosMock.onGet("/api/personalschedules?id=5").reply(404);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -108,7 +124,7 @@ describe("PersonalScheduleInfoPage tests", () => {
 
         setupAdminUser();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/personalschedules/5").reply(404);
+        axiosMock.onGet("/api/personalschedules?id=5").reply(404);
 
         render(
             <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalScheduleInfoPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalScheduleInfoPage.test.js
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+import PersonalScheduleInfoPage from "main/pages/PersonalSchedules/PersonalScheduleInfoPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { personalScheduleFixtures } from "fixtures/personalScheduleFixtures";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("PersonalScheduleInfoPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "PersonalSchedulesTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+    
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/personalschedules/1").reply(200, personalScheduleFixtures.onePersonalSchedules);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PersonalScheduleInfoPage scheduleID={"1"}/>
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/personalschedules/1").reply(200, null);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PersonalScheduleInfoPage scheduleID={"1"}/>
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("returns 404 when regular user tries to get info page of invalid id", () => {
+        jest.spyOn(console, 'error')
+        console.error.mockImplementation(() => null);
+
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/personalschedules/5").reply(404, personalScheduleFixtures.onePersonalSchedules);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PersonalScheduleInfoPage scheduleID={"5"}/>
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        console.error.mockRestore()
+
+    });
+
+    test("returns 404 when admin tries to get info page of invalid id", () => {
+        jest.spyOn(console, 'error')
+        console.error.mockImplementation(() => null);
+
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/personalschedules/5").reply(404, personalScheduleFixtures.onePersonalSchedules);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PersonalScheduleInfoPage scheduleID={"5"}/>
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        console.error.mockRestore()
+
+    });
+});

--- a/frontend/stryker.conf.json
+++ b/frontend/stryker.conf.json
@@ -15,5 +15,6 @@
         "src/main/**/*.{js,jsx,ts,tsx}",
         "!src/main/**/*_NoStryker.{js,jsx,ts,tsx}"
     ],
-    "thresholds": { "high": 100, "low": 90, "break": 100 }
+    "thresholds": { "high": 100, "low": 90, "break": 100 },
+    "timeoutMS": 30000
 }

--- a/frontend/stryker.conf.json
+++ b/frontend/stryker.conf.json
@@ -15,6 +15,5 @@
         "src/main/**/*.{js,jsx,ts,tsx}",
         "!src/main/**/*_NoStryker.{js,jsx,ts,tsx}"
     ],
-    "thresholds": { "high": 100, "low": 90, "break": 100 },
-    "timeoutMS": 30000
+    "thresholds": { "high": 100, "low": 90, "break": 100 }
 }


### PR DESCRIPTION
In this PR, I created a placeholder page that displays the PersonalScheduleTable for specific personal schedules. You can access these pages with the route `/personalschedules/{psid}`. If you try reaching a personal schedule page with an invalid ID, it will bring up the placeholder page with a blank table.

I also included a new dynamic route in App.js, and added frontend tests for PersonalScheduleInfoPage.